### PR TITLE
mardizzone/pos-944-govuln

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,25 +68,6 @@ jobs:
         with:
           version: v1.50
 
-      - name: Running govulncheck
-        if: matrix.os == 'ubuntu-20.04'
-        uses: Templum/govulncheck-action@v0.0.7
-        continue-on-error: true
-        env:
-          DEBUG: "true"
-        with:
-          go-version: 1.19
-          vulncheck-version: latest
-          package: ./...
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          fail-on-vuln: false
-
-      - name: Upload govulncheck report
-        uses: actions/upload-artifact@v3
-        with:
-          name: raw-report
-          path: raw-report.json
-
       - name: Test
         run: make test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,6 @@ concurrency:
 
 jobs:
   tests:
-    permissions:
-      security-events: write
     if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,14 +69,22 @@ jobs:
           version: v1.50
 
       - name: Running govulncheck
-        if: matrix.os == 'ubuntu-20.04'
-        uses: Templum/govulncheck-action@v0.0.6
+        uses: Templum/govulncheck-action@v0.0.7
+        continue-on-error: true
+        env:
+          DEBUG: "true"
         with:
-          go-version: 1.19
+          go-version: 1.18
           vulncheck-version: latest
           package: ./...
           github-token: ${{ secrets.GITHUB_TOKEN }}
           fail-on-vuln: false
+
+      - name: Upload govulncheck report
+        uses: actions/upload-artifact@v3
+        with:
+          name: raw-report
+          path: raw-report.json
 
       - name: Test
         run: make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,12 +69,13 @@ jobs:
           version: v1.50
 
       - name: Running govulncheck
+        if: matrix.os == 'ubuntu-20.04'
         uses: Templum/govulncheck-action@v0.0.7
         continue-on-error: true
         env:
           DEBUG: "true"
         with:
-          go-version: 1.18
+          go-version: 1.19
           vulncheck-version: latest
           package: ./...
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/security-ci.yml
+++ b/.github/workflows/security-ci.yml
@@ -46,7 +46,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Running govulncheck
-        uses: Templum/govulncheck-action@v0.0.7
+        uses: Templum/govulncheck-action@v0.0.8
         continue-on-error: true
         env:
           DEBUG: "true"

--- a/.github/workflows/security-ci.yml
+++ b/.github/workflows/security-ci.yml
@@ -39,3 +39,26 @@ jobs:
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: snyk.sarif
+
+  govuln:
+    name: Run govuln check and Publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Running govulncheck
+        uses: Templum/govulncheck-action@v0.0.7
+        continue-on-error: true
+        env:
+          DEBUG: "true"
+        with:
+          go-version: 1.18
+          vulncheck-version: latest
+          package: ./...
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fail-on-vuln: true
+
+      - name: Upload govulncheck report
+        uses: actions/upload-artifact@v3
+        with:
+          name: raw-report
+          path: raw-report.json


### PR DESCRIPTION
This PR bumps the `Templum/govulncheck-action` to a fixed version, and adds a new step to upload the raw `govuln` report as artifact. 