### PR TITLE
mardizzone/hotfix-snyk: remove vcs build when running snyk

### DIFF
--- a/.github/workflows/security-ci.yml
+++ b/.github/workflows/security-ci.yml
@@ -13,6 +13,7 @@ jobs:
         continue-on-error: true
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          GOFLAGS: "-buildvcs=false"
         with:
           args: --org=${{ secrets.SNYK_ORG }} --severity-threshold=medium --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning


### PR DESCRIPTION
# Description

Starting with `v1.18`, Go introduced version control (VCS). See [v1.18 release notes](https://tip.golang.org/doc/go1.18)
If the VCS status can't be determined for a dependency, `go list` (which Snyk tests rely upon) will fail. 

Since the pipeline is using `snyk/actions/golang@master`, it is using `docker://snyk/snyk:golang` which currently uses GOLANG_VERSION=1.20

Waiting for `snyk` team to provide a fix, they suggest to add the following to the pipeline
```
env:
    GOFLAGS: “-buildvcs=false”
```