### PR TITLE
docker push patch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB }}
           password: ${{ secrets.DOCKERHUB_KEY }}
+          
+      - name: List images
+        run: |
+            docker images     
             
       - name: Push all relevant images to docker hub
         run: |
-            docker push 0xpolygon/erigon
+            docker push 0xpolygon/erigon:${{ steps.prepare.outputs.tag_name }}-amd64
+            docker push 0xpolygon/erigon:${{ steps.prepare.outputs.tag_name }}-arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,12 +32,7 @@ jobs:
         id: prepare
         run: |
             TAG=${GITHUB_REF#refs/tags/}
-            echo ::set-output name=tag_name::${TAG}
-            
-      - name: Test tag name
-        run: |
-            TAG=${{ steps.prepare.outputs.tag_name }}
-            echo ${TAG:1}            
+            echo ::set-output name=tag_name::${TAG}         
             
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -63,6 +58,6 @@ jobs:
             
       - name: Push all relevant images to docker hub
         run: |
-            TAG=${GITHUB_REF#refs/tags/:1}
-            docker push 0xpolygon/erigon:${TAG}-amd64
-            docker push 0xpolygon/erigon:${TAG}-arm64
+            TAG=${{ steps.prepare.outputs.tag_name }}
+            docker push 0xpolygon/erigon:${TAG:1}-amd64
+            docker push 0xpolygon/erigon:${TAG:1}-arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@master
         with:
-          go-version: 1.19.x
+          go-version: 1.20.x
 
       - name: Prepare
         id: prepare

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@master
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
 
       - name: Prepare
         id: prepare

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,6 @@ jobs:
         run: |
             TAG=${GITHUB_REF#refs/tags/}
             echo ::set-output name=tag_name::${TAG}         
-            
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,13 +35,6 @@ jobs:
             echo ::set-output name=tag_name::${TAG}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
-        
-      - name: create goreleaser docker registry login file
-        id: create-json
-        uses: jsdaniell/create-json@v1.2.2
-        with:
-          name: "docker-registry.json"
-          json: ${{ secrets.DOCKER_REGISTRY_JSON }}
 
       - name: Run GoReleaser
         run: |
@@ -52,7 +45,6 @@ jobs:
           DOCKER_USERNAME: ${{ secrets.DOCKERHUB }}
           DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_KEY }}
           DOCKER_REGISTRY: hub.docker.com
-          DOCKER_CREDS_FILE: /home/runner/work/erigon/erigon/docker-registry.json
           
       - name: Log in to Docker Hub
         uses: docker/login-action@v1
@@ -63,3 +55,7 @@ jobs:
       - name: List Docker images push manually
         run: |
             docker images
+            
+      - name: Push all relevant images to docker hub
+        run: |
+            docker push 0xpolygon/erigon

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,14 +49,18 @@ jobs:
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB }}
-          password: ${{ secrets.DOCKERHUB_KEY }}
-          
-      - name: List images
-        run: |
-            docker images     
+          password: ${{ secrets.DOCKERHUB_KEY }} 
             
       - name: Push all relevant images to docker hub
         run: |
             TAG=${{ steps.prepare.outputs.tag_name }}
             docker push 0xpolygon/erigon:${TAG:1}-amd64
             docker push 0xpolygon/erigon:${TAG:1}-arm64
+            
+      - name: Combine digests into single docker tag and latest tag
+        run: |
+            TAG=${{ steps.prepare.outputs.tag_name }}
+            docker manifest create 0xpolygon/erigon:${TAG:1} --amend 0xpolygon/erigon:${TAG:1}-amd64 --amend 0xpolygon/erigon:${TAG:1}-arm64
+            docker manifest push 0xpolygon/erigon:${TAG:1}
+            docker manifest create 0xpolygon/erigon:latest --amend 0xpolygon/erigon:${TAG:1}-amd64 --amend 0xpolygon/erigon:${TAG:1}-arm64
+            docker manifest push 0xpolygon/erigon:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,3 +45,13 @@ jobs:
           DOCKER_USERNAME: ${{ secrets.DOCKERHUB }}
           DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_KEY }}
           DOCKER_REGISTRY: hub.docker.com
+          
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB }}
+          password: ${{ secrets.DOCKERHUB_KEY }}
+          
+      - name: List Docker images push manually
+        run: |
+            docker images

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,23 +38,18 @@ jobs:
 
       - name: Run GoReleaser
         run: |
-            make release
+          make release
         env:
           GITHUB_TOKEN: ${{ secrets.GIT_TOKEN }}
           VERSION: ${{ steps.prepare.outputs.tag_name }}
           DOCKER_USERNAME: ${{ secrets.DOCKERHUB }}
           DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_KEY }}
-          DOCKER_REGISTRY: hub.docker.com
           
       - name: Log in to Docker Hub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB }}
           password: ${{ secrets.DOCKERHUB_KEY }}
-          
-      - name: List Docker images push manually
-        run: |
-            docker images
             
       - name: Push all relevant images to docker hub
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,11 +42,6 @@ jobs:
         with:
           name: "docker-registry.json"
           json: ${{ secrets.DOCKER_REGISTRY_JSON }}
-          
-      - name: List files and present dir path
-        run: |
-            pwd 
-            ls
 
       - name: Run GoReleaser
         run: |
@@ -57,7 +52,7 @@ jobs:
           DOCKER_USERNAME: ${{ secrets.DOCKERHUB }}
           DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_KEY }}
           DOCKER_REGISTRY: hub.docker.com
-          DOCKER_CREDS_FILE: docker-registry.json
+          DOCKER_CREDS_FILE: /home/runner/work/erigon/erigon/docker-registry.json
           
       - name: Log in to Docker Hub
         uses: docker/login-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,11 @@ jobs:
         uses: actions/setup-go@master
         with:
           go-version: 1.20.x
+          
+      - name: Push all relevant images to docker hub
+        run: |
+            TAG=${GITHUB_REF#refs/tags/:1}
+            echo ${TAG}
 
       - name: Prepare
         id: prepare
@@ -57,5 +62,6 @@ jobs:
             
       - name: Push all relevant images to docker hub
         run: |
-            docker push 0xpolygon/erigon:${{ steps.prepare.outputs.tag_name }}-amd64
-            docker push 0xpolygon/erigon:${{ steps.prepare.outputs.tag_name }}-arm64
+            TAG=${GITHUB_REF#refs/tags/:1}
+            docker push 0xpolygon/erigon:${TAG}-amd64
+            docker push 0xpolygon/erigon:${TAG}-arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,3 +44,4 @@ jobs:
           VERSION: ${{ steps.prepare.outputs.tag_name }}
           DOCKER_USERNAME: ${{ secrets.DOCKERHUB }}
           DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_KEY }}
+          DOCKER_REGISTRY: hub.docker.com

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,12 @@ name: Release
 
 on:
   push:
+    branches-ignore:
+      - '**'
+    tags:
+      - 'v*.*.*'
+      # to be used by fork patch-releases ^^
+      - 'v*.*.*-*'
 
 jobs:
   goreleaser:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,18 @@ jobs:
             echo ::set-output name=tag_name::${TAG}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
+        
+      - name: create goreleaser docker registry login file
+        id: create-json
+        uses: jsdaniell/create-json@v1.2.2
+        with:
+          name: "docker-registry.json"
+          json: ${{ secrets.DOCKER_REGISTRY_JSON }}
+          
+      - name: List files and present dir path
+        run: |
+            pwd 
+            ls
 
       - name: Run GoReleaser
         run: |
@@ -45,6 +57,7 @@ jobs:
           DOCKER_USERNAME: ${{ secrets.DOCKERHUB }}
           DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_KEY }}
           DOCKER_REGISTRY: hub.docker.com
+          DOCKER_CREDS_FILE: docker-registry.json
           
       - name: Log in to Docker Hub
         uses: docker/login-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
         id: prepare
         run: |
             TAG=${GITHUB_REF#refs/tags/}
-            echo ::set-output name=tag_name::${TAG}         
+            echo ::set-output name=tag_name::${TAG}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,12 +7,6 @@ name: Release
 
 on:
   push:
-    branches-ignore:
-      - '**'
-    tags:
-      - 'v*.*.*'
-      # to be used by fork patch-releases ^^
-      - 'v*.*.*-*'
 
 jobs:
   goreleaser:
@@ -36,11 +30,9 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
 
-      - run: echo ${{ steps.prepare.outputs.tag_name }}
-
       - name: Run GoReleaser
         run: |
-          make release
+            make release
         env:
           GITHUB_TOKEN: ${{ secrets.GIT_TOKEN }}
           VERSION: ${{ steps.prepare.outputs.tag_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,17 +27,18 @@ jobs:
         uses: actions/setup-go@master
         with:
           go-version: 1.20.x
-          
-      - name: Push all relevant images to docker hub
-        run: |
-            TAG=${GITHUB_REF#refs/tags/:1}
-            echo ${TAG}
 
       - name: Prepare
         id: prepare
         run: |
             TAG=${GITHUB_REF#refs/tags/}
             echo ::set-output name=tag_name::${TAG}
+            
+      - name: Test tag name
+        run: |
+            TAG=${{ steps.prepare.outputs.tag_name }}
+            echo ${TAG:1}            
+            
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -70,7 +70,7 @@ dockers:
       - 0xpolygon/{{ .ProjectName }}:{{ .Version }}-amd64
     dockerfile: Dockerfile.release
     use: buildx
-    skip_push: false
+    skip_push: true
     goarch: amd64
     ids:
       - linux-amd64
@@ -80,24 +80,13 @@ dockers:
   - image_templates:
       - 0xpolygon/{{ .ProjectName }}:{{ .Version }}-arm64
     dockerfile: Dockerfile.release
-    skip_push: false
+    skip_push: true
     use: buildx
     goarch: arm64
     ids:
       - linux-arm64
     build_flag_templates:
       - --platform=linux/arm64/v8
-
-docker_manifests:
-  - name_template: 0xpolygon/{{ .ProjectName }}:{{ .Version }}
-    image_templates:
-      - 0xpolygon/{{ .ProjectName }}:{{ .Version }}-amd64
-      - 0xpolygon/{{ .ProjectName }}:{{ .Version }}-arm64
-
-  - name_template: 0xpolygon/{{ .ProjectName }}:latest
-    image_templates:
-    - 0xpolygon/{{ .ProjectName }}:{{ .Version }}-amd64
-    - 0xpolygon/{{ .ProjectName }}:{{ .Version }}-arm64
 
 announce:
   slack:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,27 +6,27 @@ release:
   prerelease: auto
 
 builds:
-  # - id: darwin-amd64
-  #   main: ./cmd/erigon
-  #   binary: erigon
-  #   goos: [ darwin ]
-  #   goarch: [ amd64 ]
-  #   env:
-  #     - CC=o64-clang
-  #     - CXX=o64-clang++
-  #   tags: [ nosqlite, noboltdb ]
-  #   ldflags: -s -w
-  # 
-  # - id: darwin-arm64
-  #   main: ./cmd/erigon
-  #   binary: erigon
-  #   goos: [ darwin ]
-  #   goarch: [ arm64 ]
-  #   env:
-  #     - CC=oa64-clang
-  #     - CXX=oa64-clang++
-  #   tags: [ nosqlite, noboltdb ]
-  #   ldflags: -s -w
+  - id: darwin-amd64
+    main: ./cmd/erigon
+    binary: erigon
+    goos: [ darwin ]
+    goarch: [ amd64 ]
+    env:
+      - CC=o64-clang
+      - CXX=o64-clang++
+    tags: [ nosqlite, noboltdb ]
+    ldflags: -s -w
+  
+  - id: darwin-arm64
+    main: ./cmd/erigon
+    binary: erigon
+    goos: [ darwin ]
+    goarch: [ arm64 ]
+    env:
+      - CC=oa64-clang
+      - CXX=oa64-clang++
+    tags: [ nosqlite, noboltdb ]
+    ldflags: -s -w
 
   - id: linux-amd64
     main: ./cmd/erigon
@@ -50,16 +50,16 @@ builds:
     tags: [ nosqlite, noboltdb ]
     ldflags: -s -w -extldflags "-static" # We need to build a static binary because we are building in a glibc based system and running in a musl container
 
-  # - id: windows-amd64
-  #   main: ./cmd/erigon
-  #   binary: erigon
-  #   goos: [ windows ]
-  #   goarch: [ amd64 ]
-  #   env:
-  #     - CC=x86_64-w64-mingw32-gcc
-  #     - CXX=x86_64-w64-mingw32-g++
-  #   tags: [ nosqlite, noboltdb ]
-  #   ldflags: -s -w
+  - id: windows-amd64
+    main: ./cmd/erigon
+    binary: erigon
+    goos: [ windows ]
+    goarch: [ amd64 ]
+    env:
+      - CC=x86_64-w64-mingw32-gcc
+      - CXX=x86_64-w64-mingw32-g++
+    tags: [ nosqlite, noboltdb ]
+    ldflags: -s -w
 
 
 snapshot:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,7 +16,7 @@ builds:
       - CXX=o64-clang++
     tags: [ nosqlite, noboltdb ]
     ldflags: -s -w
-  
+
   - id: darwin-arm64
     main: ./cmd/erigon
     binary: erigon

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -70,7 +70,7 @@ dockers:
       - 0xpolygon/{{ .ProjectName }}:{{ .Version }}-amd64
     dockerfile: Dockerfile.release
     use: buildx
-    skip_push: true
+    skip_push: false
     goarch: amd64
     ids:
       - linux-amd64
@@ -80,7 +80,7 @@ dockers:
   - image_templates:
       - 0xpolygon/{{ .ProjectName }}:{{ .Version }}-arm64
     dockerfile: Dockerfile.release
-    skip_push: true
+    skip_push: false
     use: buildx
     goarch: arm64
     ids:
@@ -88,16 +88,16 @@ dockers:
     build_flag_templates:
       - --platform=linux/arm64/v8
 
-# docker_manifests:
-#   - name_template: 0xpolygon/{{ .ProjectName }}:{{ .Version }}
-#     image_templates:
-#       - 0xpolygon/{{ .ProjectName }}:{{ .Version }}-amd64
-#       - 0xpolygon/{{ .ProjectName }}:{{ .Version }}-arm64
-# 
-#   - name_template: 0xpolygon/{{ .ProjectName }}:latest
-#     image_templates:
-#     - 0xpolygon/{{ .ProjectName }}:{{ .Version }}-amd64
-#     - 0xpolygon/{{ .ProjectName }}:{{ .Version }}-arm64
+docker_manifests:
+  - name_template: 0xpolygon/{{ .ProjectName }}:{{ .Version }}
+    image_templates:
+      - 0xpolygon/{{ .ProjectName }}:{{ .Version }}-amd64
+      - 0xpolygon/{{ .ProjectName }}:{{ .Version }}-arm64
+
+  - name_template: 0xpolygon/{{ .ProjectName }}:latest
+    image_templates:
+    - 0xpolygon/{{ .ProjectName }}:{{ .Version }}-amd64
+    - 0xpolygon/{{ .ProjectName }}:{{ .Version }}-arm64
 
 announce:
   slack:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,27 +6,27 @@ release:
   prerelease: auto
 
 builds:
-  - id: darwin-amd64
-    main: ./cmd/erigon
-    binary: erigon
-    goos: [ darwin ]
-    goarch: [ amd64 ]
-    env:
-      - CC=o64-clang
-      - CXX=o64-clang++
-    tags: [ nosqlite, noboltdb ]
-    ldflags: -s -w
-
-  - id: darwin-arm64
-    main: ./cmd/erigon
-    binary: erigon
-    goos: [ darwin ]
-    goarch: [ arm64 ]
-    env:
-      - CC=oa64-clang
-      - CXX=oa64-clang++
-    tags: [ nosqlite, noboltdb ]
-    ldflags: -s -w
+  # - id: darwin-amd64
+  #   main: ./cmd/erigon
+  #   binary: erigon
+  #   goos: [ darwin ]
+  #   goarch: [ amd64 ]
+  #   env:
+  #     - CC=o64-clang
+  #     - CXX=o64-clang++
+  #   tags: [ nosqlite, noboltdb ]
+  #   ldflags: -s -w
+  # 
+  # - id: darwin-arm64
+  #   main: ./cmd/erigon
+  #   binary: erigon
+  #   goos: [ darwin ]
+  #   goarch: [ arm64 ]
+  #   env:
+  #     - CC=oa64-clang
+  #     - CXX=oa64-clang++
+  #   tags: [ nosqlite, noboltdb ]
+  #   ldflags: -s -w
 
   - id: linux-amd64
     main: ./cmd/erigon
@@ -50,16 +50,16 @@ builds:
     tags: [ nosqlite, noboltdb ]
     ldflags: -s -w -extldflags "-static" # We need to build a static binary because we are building in a glibc based system and running in a musl container
 
-  - id: windows-amd64
-    main: ./cmd/erigon
-    binary: erigon
-    goos: [ windows ]
-    goarch: [ amd64 ]
-    env:
-      - CC=x86_64-w64-mingw32-gcc
-      - CXX=x86_64-w64-mingw32-g++
-    tags: [ nosqlite, noboltdb ]
-    ldflags: -s -w
+  # - id: windows-amd64
+  #   main: ./cmd/erigon
+  #   binary: erigon
+  #   goos: [ windows ]
+  #   goarch: [ amd64 ]
+  #   env:
+  #     - CC=x86_64-w64-mingw32-gcc
+  #     - CXX=x86_64-w64-mingw32-g++
+  #   tags: [ nosqlite, noboltdb ]
+  #   ldflags: -s -w
 
 
 snapshot:
@@ -70,7 +70,7 @@ dockers:
       - 0xpolygon/{{ .ProjectName }}:{{ .Version }}-amd64
     dockerfile: Dockerfile.release
     use: buildx
-    skip_push: false
+    skip_push: true
     goarch: amd64
     ids:
       - linux-amd64
@@ -80,7 +80,7 @@ dockers:
   - image_templates:
       - 0xpolygon/{{ .ProjectName }}:{{ .Version }}-arm64
     dockerfile: Dockerfile.release
-    skip_push: false
+    skip_push: true
     use: buildx
     goarch: arm64
     ids:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,27 +6,27 @@ release:
   prerelease: auto
 
 builds:
-  - id: darwin-amd64
-    main: ./cmd/erigon
-    binary: erigon
-    goos: [ darwin ]
-    goarch: [ amd64 ]
-    env:
-      - CC=o64-clang
-      - CXX=o64-clang++
-    tags: [ nosqlite, noboltdb ]
-    ldflags: -s -w
-
-  - id: darwin-arm64
-    main: ./cmd/erigon
-    binary: erigon
-    goos: [ darwin ]
-    goarch: [ arm64 ]
-    env:
-      - CC=oa64-clang
-      - CXX=oa64-clang++
-    tags: [ nosqlite, noboltdb ]
-    ldflags: -s -w
+  # - id: darwin-amd64
+  #   main: ./cmd/erigon
+  #   binary: erigon
+  #   goos: [ darwin ]
+  #   goarch: [ amd64 ]
+  #   env:
+  #     - CC=o64-clang
+  #     - CXX=o64-clang++
+  #   tags: [ nosqlite, noboltdb ]
+  #   ldflags: -s -w
+  # 
+  # - id: darwin-arm64
+  #   main: ./cmd/erigon
+  #   binary: erigon
+  #   goos: [ darwin ]
+  #   goarch: [ arm64 ]
+  #   env:
+  #     - CC=oa64-clang
+  #     - CXX=oa64-clang++
+  #   tags: [ nosqlite, noboltdb ]
+  #   ldflags: -s -w
 
   - id: linux-amd64
     main: ./cmd/erigon
@@ -50,16 +50,16 @@ builds:
     tags: [ nosqlite, noboltdb ]
     ldflags: -s -w -extldflags "-static" # We need to build a static binary because we are building in a glibc based system and running in a musl container
 
-  - id: windows-amd64
-    main: ./cmd/erigon
-    binary: erigon
-    goos: [ windows ]
-    goarch: [ amd64 ]
-    env:
-      - CC=x86_64-w64-mingw32-gcc
-      - CXX=x86_64-w64-mingw32-g++
-    tags: [ nosqlite, noboltdb ]
-    ldflags: -s -w
+  # - id: windows-amd64
+  #   main: ./cmd/erigon
+  #   binary: erigon
+  #   goos: [ windows ]
+  #   goarch: [ amd64 ]
+  #   env:
+  #     - CC=x86_64-w64-mingw32-gcc
+  #     - CXX=x86_64-w64-mingw32-g++
+  #   tags: [ nosqlite, noboltdb ]
+  #   ldflags: -s -w
 
 
 snapshot:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -88,16 +88,16 @@ dockers:
     build_flag_templates:
       - --platform=linux/arm64/v8
 
-docker_manifests:
-  - name_template: 0xpolygon/{{ .ProjectName }}:{{ .Version }}
-    image_templates:
-      - 0xpolygon/{{ .ProjectName }}:{{ .Version }}-amd64
-      - 0xpolygon/{{ .ProjectName }}:{{ .Version }}-arm64
-
-  - name_template: 0xpolygon/{{ .ProjectName }}:latest
-    image_templates:
-    - 0xpolygon/{{ .ProjectName }}:{{ .Version }}-amd64
-    - 0xpolygon/{{ .ProjectName }}:{{ .Version }}-arm64
+# docker_manifests:
+#   - name_template: 0xpolygon/{{ .ProjectName }}:{{ .Version }}
+#     image_templates:
+#       - 0xpolygon/{{ .ProjectName }}:{{ .Version }}-amd64
+#       - 0xpolygon/{{ .ProjectName }}:{{ .Version }}-arm64
+# 
+#   - name_template: 0xpolygon/{{ .ProjectName }}:latest
+#     image_templates:
+#     - 0xpolygon/{{ .ProjectName }}:{{ .Version }}-amd64
+#     - 0xpolygon/{{ .ProjectName }}:{{ .Version }}-arm64
 
 announce:
   slack:

--- a/Makefile
+++ b/Makefile
@@ -227,8 +227,6 @@ release-dry-run: git-submodules
 		-e GITHUB_TOKEN \
 		-e DOCKER_USERNAME \
 		-e DOCKER_PASSWORD \
-		-e DOCKER_REGISTRY \
-		-e DOCKER_CREDS_FILE \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v `pwd`:/go/src/$(PACKAGE_NAME) \
 		-w /go/src/$(PACKAGE_NAME) \
@@ -244,8 +242,6 @@ release: git-submodules
 		-e GITHUB_TOKEN \
 		-e DOCKER_USERNAME \
 		-e DOCKER_PASSWORD \
-		-e DOCKER_REGISTRY \
-		-e DOCKER_CREDS_FILE \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v `pwd`:/go/src/$(PACKAGE_NAME) \
 		-w /go/src/$(PACKAGE_NAME) \

--- a/Makefile
+++ b/Makefile
@@ -228,6 +228,7 @@ release-dry-run: git-submodules
 		-e DOCKER_USERNAME \
 		-e DOCKER_PASSWORD \
 		-e DOCKER_REGISTRY \
+		-e DOCKER_CREDS_FILE \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v `pwd`:/go/src/$(PACKAGE_NAME) \
 		-w /go/src/$(PACKAGE_NAME) \
@@ -244,6 +245,7 @@ release: git-submodules
 		-e DOCKER_USERNAME \
 		-e DOCKER_PASSWORD \
 		-e DOCKER_REGISTRY \
+		-e DOCKER_CREDS_FILE \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v `pwd`:/go/src/$(PACKAGE_NAME) \
 		-w /go/src/$(PACKAGE_NAME) \

--- a/Makefile
+++ b/Makefile
@@ -216,7 +216,7 @@ git-submodules:
 	@git submodule update --quiet --init --recursive --force || true
 
 PACKAGE_NAME          := github.com/maticnetwork/erigon
-GOLANG_CROSS_VERSION  ?= v1.18.1
+GOLANG_CROSS_VERSION  ?= v1.20.5
 
 .PHONY: release-dry-run
 release-dry-run: git-submodules
@@ -227,6 +227,7 @@ release-dry-run: git-submodules
 		-e GITHUB_TOKEN \
 		-e DOCKER_USERNAME \
 		-e DOCKER_PASSWORD \
+		-e DOCKER_REGISTRY \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v `pwd`:/go/src/$(PACKAGE_NAME) \
 		-w /go/src/$(PACKAGE_NAME) \
@@ -242,6 +243,7 @@ release: git-submodules
 		-e GITHUB_TOKEN \
 		-e DOCKER_USERNAME \
 		-e DOCKER_PASSWORD \
+		-e DOCKER_REGISTRY \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v `pwd`:/go/src/$(PACKAGE_NAME) \
 		-w /go/src/$(PACKAGE_NAME) \


### PR DESCRIPTION
**purpose:**
latest version of goreleaser-cross has no clear way of logging into docker hub directly, breaking automatic release of erigon images. however, latest erigon client code requires go v1.20+ to successfully compile builds. therefore, we've switched the process of uploading new erigon docker images using an additional custom github actions step

the resulting image artifacts (multi architecture) are tagged and grouped identically as the old method, as seen here: https://hub.docker.com/r/0xpolygon/erigon/tags

**tests:**
e2e github actions test and successful image upload to docker hub, per: https://github.com/maticnetwork/erigon/actions/runs/5316079632/jobs/9625214446